### PR TITLE
feat: add android support

### DIFF
--- a/src/downloadRipGrep.js
+++ b/src/downloadRipGrep.js
@@ -98,6 +98,15 @@ const untarGz = async (inFile, outDir) => {
 }
 
 export const downloadRipGrep = async (overrideBinPath) => {
+  const platform = process.env.platform || os.platform()
+  if (platform === 'android') {
+    try {
+      await execa('pkg', ['install', 'ripgrep', '-y'])
+      return
+    } catch (error) {
+      console.info('Could not install ripgrep via pkg. Falling back to download.')
+    }
+  }
   const target = getTarget()
   const url = `https://github.com/${REPOSITORY}/releases/download/${VERSION}/ripgrep-${VERSION}-${target}`
   const downloadPath = `${xdgCache}/vscode-ripgrep/ripgrep-${VERSION}-${target}`

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 import { execa } from 'execa'
 import { mkdtemp, writeFile } from 'fs/promises'
-import { tmpdir } from 'os'
+import { tmpdir, platform } from 'os'
 import { join } from 'path'
 import { rgPath } from '../src/index.js'
 
@@ -11,6 +11,7 @@ const getTmpDir = () => {
 test('rgPath', async () => {
   const tmpDir = await getTmpDir()
   await writeFile(`${tmpDir}/sample-file.txt`, 'sample text')
-  const { stdout } = await execa(rgPath, ['sample', '.'], { cwd: tmpDir })
+  const command = platform() === 'android' ? 'rg' : rgPath
+  const { stdout } = await execa(command, ['sample', '.'], { cwd: tmpDir })
   expect(stdout).toContain('sample-file.txt:sample text')
 })


### PR DESCRIPTION
Fixes #55

- Modified `downloadRipGrep.js` to handle the `android` platform by using `pkg install ripgrep`.
- Modified `test/test.js` to use the system's `rg` on Android.